### PR TITLE
Add network setup process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 LDFLAGS = -ldflags '-s -w'
 
 .PHONY: build
-build: host-switch vm-switch
+build: host-switch vm-switch network-setup
 
 bin/host-switch.exe:
 	GOOS=windows go build $(LDFLAGS) -o $@ ./cmd/host
@@ -14,6 +14,12 @@ bin/vm-switch:
 
 .PHONY: vm-switch
 vm-switch: bin/vm-switch
+
+bin/network-setup:
+	GOOS=linux go build $(LDFLAGS) -o $@ ./cmd/network
+
+.PHONY: network-setup
+network-setup: bin/network-setup
 
 .PHONY: fmt
 fmt:

--- a/cmd/network/setup_linux.go
+++ b/cmd/network/setup_linux.go
@@ -1,0 +1,193 @@
+/*
+Copyright © 2023 SUSE LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"strconv"
+
+	"github.com/linuxkit/virtsock/pkg/vsock"
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netns"
+
+	"github.com/rancher-sandbox/rancher-desktop-networking/pkg/log"
+	rdvsock "github.com/rancher-sandbox/rancher-desktop-networking/pkg/vsock"
+)
+
+var (
+	debug           bool
+	vmSwitchPath    string
+	unshareArg      string
+	logFile         string
+	vmSwitchLogFile string
+)
+
+const (
+	nsenter            = "/usr/bin/nsenter"
+	unshare            = "/usr/bin/unshare"
+	vsockHandshakePort = 6669
+	vsockDialPort      = 6656
+)
+
+func main() {
+	flag.BoolVar(&debug, "debug", false, "enable additional debugging")
+	flag.StringVar(&vmSwitchPath, "vm-switch-path", "", "the path to the vm-switch binary that will run in a new namespace")
+	flag.StringVar(&vmSwitchLogFile, "vm-switch-logfile", "", "path to the logfile for vm-switch process")
+	flag.StringVar(&unshareArg, "unshare-arg", "", "the command argument to pass to the unshare program")
+	flag.StringVar(&logFile, "logfile", "/var/log/network-setup.log", "path to the logfile for network setup process")
+	flag.Parse()
+
+	if err := log.SetOutputFile(logFile, logrus.StandardLogger()); err != nil {
+		logrus.Fatalf("setting logger's output file failed: %v", err)
+	}
+
+	if debug {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+
+	if vmSwitchPath == "" {
+		logrus.Fatal("path to the vm-switch process must be provided")
+	}
+
+	if unshareArg == "" {
+		logrus.Fatal("unshare program arg must be provided")
+	}
+
+	// listenForHandshake blocks until a successful handshake is estabilished.
+	listenForHandshake()
+
+	logrus.Debugf("attempting to connect to the host on CID: %v and Port: %d", vsock.CIDHost, vsockDialPort)
+	vsockConn, err := vsock.Dial(vsock.CIDHost, vsockDialPort)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	logrus.Debugf("successful connection to host on CID: %v and Port: %d: connection: %+v", vsock.CIDHost, vsockDialPort, vsockConn)
+
+	// setup network namespace
+	ns, err := configureNamespace()
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	if err := unshareCmd(ns, unshareArg); err != nil {
+		logrus.Fatal(err)
+	}
+
+	// Start the vm-switch process in the new namespace; we do
+	// this as the golang runtime can switch threads at will, so it
+	// is safer to have a whole process in a consistent namespace.
+	args := []string{
+		fmt.Sprintf("-n/proc/%d/fd/%d", os.Getpid(), ns),
+		"-F",
+		vmSwitchPath,
+	}
+	if vmSwitchLogFile != "" {
+		args = append(args, "-logfile", vmSwitchLogFile)
+	}
+	if debug {
+		args = append(args, "-debug")
+	}
+	vmSwitchCmd := exec.Command(nsenter, args...)
+
+	connFile, err := vsockConn.File()
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	// pass in the vsock connection as a FD to the
+	// vm-switch process in the newely created namespace
+	vmSwitchCmd.ExtraFiles = []*os.File{connFile}
+	if err := vmSwitchCmd.Start(); err != nil {
+		logrus.Fatalf("could not start the vm-switch process: %v", err)
+	}
+	logrus.Infof("successfully started the vm-switch running with a PID: %v", vmSwitchCmd.Process.Pid)
+
+	if err := vmSwitchCmd.Wait(); err != nil {
+		logrus.Errorf("vm-switch exited with error: %v", err)
+	}
+}
+
+func unshareCmd(ns netns.NsHandle, args string) error {
+	unshareCmd := exec.Command( //nolint:gosec // no security concern with the potentially tainted command arguments
+		nsenter, fmt.Sprintf("-n/proc/%d/fd/%d", os.Getpid(), ns), "-F",
+		unshare, "--pid", "--mount-proc", "--fork", "--propagation", "slave", args)
+	unshareCmd.Stdout = os.Stdout
+	unshareCmd.Stderr = os.Stderr
+	if err := unshareCmd.Start(); err != nil {
+		return fmt.Errorf("could not start the unshare process: %w", err)
+	}
+
+	if err := writeWSLInitPid(unshareCmd.Process.Pid); err != nil {
+		return fmt.Errorf("writing wsl-init.pid failed: %w", err)
+	}
+
+	logrus.Debugf("successfully wrote wsl-init.pid with: %d", unshareCmd.Process.Pid)
+	return nil
+}
+
+func writeWSLInitPid(pid int) error {
+	unsharePID := strconv.Itoa(pid)
+
+	writePermission := 0600
+	err := os.WriteFile("/run/wsl-init.pid", []byte(unsharePID), fs.FileMode(writePermission))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func listenForHandshake() {
+	logrus.Info("starting handshake process with host-switch")
+	l, err := vsock.Listen(vsock.CIDAny, vsockHandshakePort)
+	if err != nil {
+		logrus.Error(err)
+	}
+	defer l.Close()
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			logrus.Errorf("listenForHandshake connection accept failed: %v", err)
+			continue
+		}
+		_, err = conn.Write([]byte(rdvsock.SignaturePhrase))
+		if err != nil {
+			logrus.Errorf("listenForHandshake writing signature phrase failed: %v", err)
+		}
+
+		// verify that the host-switch is ready for us to estabilish the connection
+		buf := make([]byte, len(rdvsock.ReadySignal))
+		if _, err := io.ReadFull(conn, buf); err != nil {
+			logrus.Errorf("listenForHandshake reading signature phrase failed: %v", err)
+		}
+		if string(buf) == rdvsock.ReadySignal {
+			break
+		}
+		conn.Close()
+	}
+	logrus.Info("listenForHandshake successful handshake with host-switch")
+}
+
+func configureNamespace() (netns.NsHandle, error) {
+	ns, err := netns.New()
+	if err != nil {
+		return netns.None(), fmt.Errorf("creating new namespace failed")
+	}
+
+	logrus.Infof("created a new namespace %v %v", ns, ns.String())
+	return ns, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/songgao/packets v0.0.0-20160404182456-549a10cd4091
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
 	github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852
+	github.com/vishvananda/netns v0.0.0-20211101163701-50045581ed74
 	golang.org/x/sync v0.1.0
 	golang.org/x/sys v0.4.0
 	gvisor.dev/gvisor v0.0.0-20221216231429-a78e892a26d2
@@ -26,7 +27,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rancher-sandbox/rancher-desktop/src/go/wsl-helper v0.0.0-20220712232929-bac01a348036 // indirect
 	github.com/u-root/uio v0.0.0-20210528114334-82958018845c // indirect
-	github.com/vishvananda/netns v0.0.0-20211101163701-50045581ed74 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/mod v0.6.0 // indirect
 	golang.org/x/net v0.4.0 // indirect

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,33 @@
+package log
+
+/*
+Copyright © 2023 SUSE LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+const fileMode = 0666
+
+// SetOutputFile sets the logger output with a given file
+func SetOutputFile(filePath string, logger *logrus.Logger) error {
+	logFile, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, fileMode)
+	if err != nil {
+		return err
+	}
+	logger.SetOutput(logFile)
+
+	return nil
+}

--- a/pkg/vsock/constants.go
+++ b/pkg/vsock/constants.go
@@ -1,0 +1,19 @@
+/*
+Copyright © 2023 SUSE LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsock
+
+const (
+	SignaturePhrase = "github.com/rancher-sandbox/rancher-desktop-networking"
+	ReadySignal     = "READY"
+)


### PR DESCRIPTION
This PR adds a process that creates the network namespace and starts the VM switch in the newly created namespace. This process will be started outside of the main `init` process. There will be a follow-up PR in Rancher Desktop to add the startup for this process in `wsl-init`. With this process in place, the virtual network should start correctly in an isolated network namespace with its own tap device that talks to the host.

Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/3956

You can test by:

Build:
```
make clean && make build
```
Copy `./bin/vm-switch` and `./bin/network-setup` to  WSL VM `/usr/loca/bin/`

Edit the wsl-init so that it can start the `network-setup` process (replace the `unshare`). Mine looks like below:
```
if [ $$ -ne "1" ]; then
    # This is not running as PID 1; this means that this is a normal invocation
    # from WSL.  Set up the namespaces, and try again.
    #echo $$ > /run/wsl-init.pid
    #exec /usr/bin/unshare --pid --mount-proc --fork --propagation slave "${0}"
    exec /usr/local/bin/network-setup -debug -vm-switch-path /usr/local/bin/vm-switch -unshare-arg "${0}" >>/var/log/wsl-init.log 2>&1
fi
```
Run RD in dev mode:
```
npm run dev
```
Start the `host-switch.exe`
```
.\host-switch.exe -debug -port-forward 127.0.0.1:6443=192.168.127.2:6443
```

Once RD started:

Confirm that the network interfaces are unchanged in the current namespace:
```
ip -o a
```
Should not be impacted.

Hopping on the new namespace:

```
 nsenter -n/run/netns/rd1
```
or 
```
nsenter -n -t vm-switch-pid
```
Confirm network interfaces:
```
ip -o a
```
The `eth0` should show up with a correct subnet IP (`192.168.127.2/24`)
```
1: lo    inet 127.0.0.1/8 scope host lo\       valid_lft forever preferred_lft forever
1: lo    inet6 ::1/128 scope host \       valid_lft forever preferred_lft forever
4: eth0    inet 192.168.127.2/24 scope global eth0\       valid_lft forever preferred_lft forever
4: eth0    inet6 fe80::5894:efff:fee4:cee/64 scope link \       valid_lft forever preferred_lft forever
5: docker0    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0\       valid_lft forever preferred_lft forever
```
DNS should get resolved at the Virtual network gateway:

```
nslooup google.ca
```
```
Server:         192.168.127.1 
Address:        192.168.127.1:53
```





