### PR TITLE
K8sAPI address requires HTTPS scheme

### DIFF
--- a/cmd/proxy/wsl_integration_linux.go
+++ b/cmd/proxy/wsl_integration_linux.go
@@ -34,7 +34,7 @@ var (
 )
 
 const (
-	k8sAPI            = "http://192.168.1.2:6443"
+	k8sAPI            = "https://192.168.1.2:6443"
 	defaultListenAddr = "127.0.0.1:6443"
 )
 


### PR DESCRIPTION
The default k8sAPI address was defined with HTTP which causes the following error:

```
Client sent an HTTP request to an HTTPS server.
```
Related to: https://github.com/rancher-sandbox/rancher-desktop/issues/6245