### PR TITLE
Allows for HTTPS connections

### DIFF
--- a/cmd/proxy/wsl_integration_linux.go
+++ b/cmd/proxy/wsl_integration_linux.go
@@ -3,130 +3,110 @@ Copyright © 2024 SUSE LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package main
 
 import (
-	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"flag"
-	"net/http"
-	"net/http/httputil"
-	"net/url"
+	"io"
+	"net"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
-	"time"
 
 	"github.com/sirupsen/logrus"
 )
 
 var (
-	debug                  bool
-	upstreamAddr           string
-	listenAddr             string
-	keyFile                string
-	certFile               string
-	rootCA                 string
-	upstreamClientKeyFile  string
-	upstreamClientCertFile string
+	debug        bool
+	upstreamAddr string
+	listenAddr   string
 )
 
 const (
-	k8sAPI               = "https://192.168.1.2:6443"
-	defaultListenAddr    = "127.0.0.1:6443"
-	kubeAPIServerKeyFile = "/var/lib/rancher/k3s/server/tls/serving-kube-apiserver.key"
-	kubeAPIServerCrtFile = "/var/lib/rancher/k3s/server/tls/serving-kube-apiserver.crt"
-	rootCACrtFile        = "/var/lib/rancher/k3s/server/tls/server-ca.crt"
-	clientAdminKeyFile   = "/var/lib/rancher/k3s/server/tls/client-admin.key"
-	clientAdminCrtFile   = "/var/lib/rancher/k3s/server/tls/client-admin.crt"
+	k8sAPI            = "192.168.1.2:6443"
+	defaultListenAddr = "127.0.0.1:6443"
 )
 
 func main() {
 	flag.BoolVar(&debug, "debug", false, "enable additional debugging.")
 	flag.StringVar(&upstreamAddr, "upstream-addr", k8sAPI, "The upstream server's address (k3s API sever).")
 	flag.StringVar(&listenAddr, "listen-addr", defaultListenAddr, "The server's address in an IP:PORT format.")
-	flag.StringVar(&keyFile, "key-file", kubeAPIServerKeyFile,
-		"TLS private key file for downstream (incoming) connection into proxy from kubectl.")
-	flag.StringVar(&certFile, "cert-file", kubeAPIServerCrtFile,
-		"TLS certificate file for downstream (incoming) connection into proxy from kubectl.")
-	flag.StringVar(&rootCA, "root-ca-file", rootCACrtFile,
-		"root ca file for upstream connection, this is the K3s API server's root CA.")
-	flag.StringVar(&upstreamClientKeyFile, "upstream-key-file", clientAdminKeyFile,
-		"Clinet TLS private key file for upstream (outgoing) connection to K3s API server.")
-	flag.StringVar(&upstreamClientCertFile, "upstream-cert-file", clientAdminCrtFile,
-		"Client TLS certificate file for upstream (outgoing) connection to K3s API server.")
 	flag.Parse()
 
 	if debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
 
-	targetURL, err := url.Parse(upstreamAddr)
+	listener, err := net.Listen("tcp", listenAddr)
 	if err != nil {
-		logrus.Fatalf("invalid upstream URL: %s", upstreamAddr)
+		logrus.Fatalf("Failed to listen on %s: %s", listenAddr, err)
 	}
 
-	ctx, _ := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	proxy := httputil.NewSingleHostReverseProxy(targetURL)
+	// Handle graceful shutdown
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
-	certPool, err := x509.SystemCertPool()
-	if err != nil {
-		logrus.Fatalf("failed loading System Cert Pool: %v", err)
-	}
-
-	crtByte, err := os.ReadFile(rootCA)
-	if err != nil {
-		logrus.Fatalf("failed reading upstream CA Cert: %v", err)
-	}
-
-	ok := certPool.AppendCertsFromPEM(crtByte)
-	if !ok {
-		logrus.Fatal("failed to append Root CA PEM")
-	}
-
-	upstreamKeyPair, err := tls.LoadX509KeyPair(upstreamClientCertFile, upstreamClientKeyFile)
-	if err != nil {
-		logrus.Fatalf("failed to load upstream certificate/key: %v", err)
-	}
-	proxy.Transport = &http.Transport{
-		TLSClientConfig: &tls.Config{
-			MinVersion:   tls.VersionTLS13, // Match k3s API TLS version
-			Certificates: []tls.Certificate{upstreamKeyPair},
-			RootCAs:      certPool,
-		},
-	}
-
-	srv := http.Server{
-		Addr:              listenAddr,
-		Handler:           proxy,
-		ReadHeaderTimeout: 5 * time.Second,
-	}
-
-	srv.TLSConfig = &tls.Config{
-		MinVersion:               tls.VersionTLS13,
-		PreferServerCipherSuites: true,
-	}
+	// WaitGroup to wait for all connections to finish before shutting down
+	var wg sync.WaitGroup
 
 	go func() {
-		if err := srv.ListenAndServeTLS(certFile, keyFile); !errors.Is(err, http.ErrServerClosed) {
-			logrus.Error("Error starting server:", err)
+		<-sigCh
+		logrus.Println("Shutting down...")
+		listener.Close()
+		wg.Wait()
+		os.Exit(0)
+	}()
+
+	logrus.Infof("Proxy server started listening on %s, forwarding to %s", listenAddr, upstreamAddr)
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			// Check if the error is due to listener being closed
+			if errors.Is(err, net.ErrClosed) {
+				break
+			}
+			logrus.Errorf("Failed to accept listener: %s", err)
+			continue
+		}
+		logrus.Debugf("Accepted connection from %s", conn.RemoteAddr())
+
+		wg.Add(1)
+
+		go func(conn net.Conn) {
+			defer wg.Done()
+			defer conn.Close()
+			pipe(conn, upstreamAddr)
+		}(conn)
+	}
+}
+
+func pipe(conn net.Conn, upstreamAddr string) {
+	upstream, err := net.Dial("tcp", upstreamAddr)
+	if err != nil {
+		logrus.Errorf("Failed to dial upstream %s: %s", upstreamAddr, err)
+		return
+	}
+	defer upstream.Close()
+
+	go func() {
+		if _, err := io.Copy(upstream, conn); err != nil {
+			logrus.Debugf("Error copying to upstream: %s", err)
 		}
 	}()
 
-	logrus.Debugf("proxy server is running on %s", listenAddr)
-	<-ctx.Done()
-
-	if err := srv.Shutdown(context.Background()); err != nil {
-		logrus.Error("Error shutting down server:", err)
+	if _, err := io.Copy(conn, upstream); err != nil {
+		logrus.Debugf("Error copying from upstream: %s", err)
 	}
 }


### PR DESCRIPTION
The wsl-proxy can now accept HTTP connections for downstream clients and establishes an upstream HTTPS connection to the k3s server. 

Related to: https://github.com/rancher-sandbox/rancher-desktop/issues/6245
Fixes: https://github.com/rancher-sandbox/rancher-desktop/issues/6547