### PR TITLE
Disable debug mode in vm-switch by default

### DIFF
--- a/cmd/vm/switch_linux.go
+++ b/cmd/vm/switch_linux.go
@@ -52,7 +52,7 @@ const (
 )
 
 func main() {
-	flag.BoolVar(&debug, "debug", true, "enable debug flag")
+	flag.BoolVar(&debug, "debug", false, "enable debug flag")
 	flag.StringVar(&tapIface, "tap-interface", defaultTapDevice, "tap interface name, eg. eth0, eth1")
 	flag.StringVar(&tapDeviceMacAddr, "tap-mac-address", config.TapDeviceMacAddr,
 		"MAC address that is associated to the tap interface")


### PR DESCRIPTION
By default vm-switch is started in debug mode, generating logs for every routed packet. But since the logfile is mounted from the host system (WSL2/9p), every packet operation is blocked by logging mechanism, resulting in bad network performance.

https://github.com/rancher-sandbox/rancher-desktop/issues/6671