### PR TITLE
golangci-lint: Update for 1.58

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,7 +22,7 @@ linters-settings:
       - wrapperFunc
   gocyclo:
     min-complexity: 15
-  gomnd:
+  mnd:
     # don't include the "operation" and "assign"
     checks:
       - argument
@@ -42,7 +42,6 @@ linters-settings:
   misspell:
     locale: US
   nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
     allow-unused: false # report any unused nolint directives
     require-explanation: false # don't require an explanation for nolint directives
     require-specific: false # don't require nolint directives to be specific about which linter is being skipped
@@ -51,7 +50,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - dogsled
     - dupl
     - errcheck
@@ -62,7 +60,6 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - gomnd
     - goprintffuncname
     - gosec
     - gosimple
@@ -70,17 +67,16 @@ linters:
     - ineffassign
     - lll
     - misspell
+    - mnd
     - nakedret
     - noctx
     - nolintlint
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
 
   # don't enable:


### PR DESCRIPTION
- Drop obsolete linters `deadcode`, `structcheck`, `varcheck`; these have been replaced by `unused` (which we already have).
- The `gomnd` linter has been renamed to `mnd`.
- Drop `nolintlint` config `allow-leading-space`; that is no longer accepted (and doesn't trigger anything).