### PR TITLE
network-setup: Force remove veth before setting up

### DIFF
--- a/cmd/network/setup_linux.go
+++ b/cmd/network/setup_linux.go
@@ -91,6 +91,9 @@ func main() {
 		logrus.Errorf("failed getting a handle to the current namespace: %v", err)
 	}
 
+	// Remove any existing veth devices (before we set up network namespaces)
+	cleanupVethLink(originNS)
+
 	// setup network namespace
 	ns, err := configureNamespace()
 	if err != nil {


### PR DESCRIPTION
Since factory-reset does not allow for graceful shutdown, we may have an existing `veth-rd0` device in the default namespace.  Fix the case by forcefully attempting to delete the interface if it exists before we set up network namespaces (and ignore any failures).