### PR TITLE
Close active listeners

### DIFF
--- a/pkg/portproxy/server.go
+++ b/pkg/portproxy/server.go
@@ -135,6 +135,9 @@ func (p *PortProxy) acceptTraffic(listener net.Listener, port string) {
 }
 
 func (p *PortProxy) Close() error {
+	// Close all the active listeners
+	p.cleanupListeners()
+
 	// Close the listener first to prevent new connections.
 	err := p.listener.Close()
 	if err != nil {
@@ -148,4 +151,10 @@ func (p *PortProxy) Close() error {
 	p.wg.Wait()
 
 	return nil
+}
+
+func (p *PortProxy) cleanupListeners() {
+	for _, l := range p.activeListeners {
+		_ = l.Close()
+	}
 }


### PR DESCRIPTION
Sometimes there is no guarantee that we receive the final portmapping from the rancher-desktop-guest agent during the shutdown process. Therefore, we should always cleanup all the active listeners ourselves before shutdown.

Related: https://github.com/rancher-sandbox/rancher-desktop/issues/6925